### PR TITLE
Prevent calls to `GetObjectAcl ` when copying and moving files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/src/CloudflareR2Adapter.php
+++ b/src/CloudflareR2Adapter.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace jrrdnx\cloudflarer2;
+
+use League\Flysystem\AwsS3V3\AwsS3V3Adapter;
+use League\Flysystem\FileAttributes;
+use League\Flysystem\Visibility;
+
+class CloudflareR2Adapter extends AwsS3V3Adapter
+{
+    public function visibility(string $path): FileAttributes
+    {
+        // R2 assets are always private
+        return new FileAttributes($path, null, Visibility::PRIVATE);
+    }
+}

--- a/src/Fs.php
+++ b/src/Fs.php
@@ -403,26 +403,6 @@ class Fs extends FlysystemFs
     }
 
     /**
-     * Returns the parsed CloudFront distribution prefix
-     *
-     * @return string
-     */
-    private function _cfPrefix(): string
-    {
-        return '';
-    }
-
-    /**
-     * Get a CloudFront client.
-     *
-     * @return null
-     */
-    private function _getCloudFrontClient()
-    {
-        return null;
-    }
-
-    /**
      * Get the config array for AWS Clients.
      *
      * @return array

--- a/src/Fs.php
+++ b/src/Fs.php
@@ -245,12 +245,12 @@ class Fs extends FlysystemFs
 
     /**
      * @inheritdoc
-     * @return AwsS3V3Adapter
+     * @return FilesystemAdapter
      */
     protected function createAdapter(): FilesystemAdapter
     {
         $client = static::client($this->_getConfigArray(), $this->_getCredentials());
-        return new AwsS3V3Adapter($client, App::parseEnv($this->bucket), $this->_subfolder(), new PortableVisibilityConverter($this->visibility()), null, [], false);
+        return new CloudflareR2Adapter($client, App::parseEnv($this->bucket), $this->_subfolder(), new PortableVisibilityConverter($this->visibility()), null, [], false);
     }
 
     /**


### PR DESCRIPTION
Fixes #6 by marking all objects from R2 as "private" by default, rather than calling `GetObjectAcl` to determine the public/private status of an object when calling either `copy()` or `move()` (and possibly in some other places)

See https://developers.cloudflare.com/r2/api/s3/api/#unimplemented-object-level-operations